### PR TITLE
Update validation and masking behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Masking of the document will now occur only on the `blur` event.
-- The input now allows any character to be typed, not only numbers.
+- The document input now allows any character.
 
 ## [0.1.0] - 2020-03-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Masking of the document will now occur only on the `blur` event.
+- The input now allows any character to be typed, not only numbers.
 
 ## [0.1.0] - 2020-03-24
-
 ### Added
-
 - Initial implementation for `DocumentField` component.

--- a/react/.eslintrc
+++ b/react/.eslintrc
@@ -6,6 +6,7 @@
     "jest": true
   },
   "rules": {
-    "@typescript-eslint/ban-ts-ignore": "off"
+    "@typescript-eslint/ban-ts-ignore": "off",
+    "no-void": "off"
   }
 }

--- a/react/__tests__/DocumentField.test.tsx
+++ b/react/__tests__/DocumentField.test.tsx
@@ -133,4 +133,30 @@ describe('DocumentField', () => {
 
     expect(input).toHaveValue('abc123.,[]&*()')
   })
+
+  it('should be able to mask a partially masked BRA document', () => {
+    const ComponentWithPartialDoc = () => {
+      const [doc, setDoc] = React.useState('')
+      return (
+        <DocumentField
+          label="Document"
+          documentType="cpf"
+          document={doc}
+          onChange={(data: { document: string }) => setDoc(data.document)}
+        />
+      )
+    }
+
+    const { getByLabelText } = render(<ComponentWithPartialDoc />)
+
+    const input = getByLabelText(/document/i)
+
+    fireEvent.focus(input)
+
+    fireEvent.change(input, { target: { value: '123.45678901' } })
+
+    fireEvent.blur(input)
+
+    expect(input).toHaveValue('123.456.789-01')
+  })
 })

--- a/react/__tests__/DocumentField.test.tsx
+++ b/react/__tests__/DocumentField.test.tsx
@@ -1,16 +1,18 @@
 import * as React from 'react'
-import { render, fireEvent } from '@vtex/test-tools/react'
+import { render, fireEvent, wait } from '@vtex/test-tools/react'
 
 import DocumentField from '../DocumentField'
 
 describe('DocumentField', () => {
-  it('should correctly mask BRA documents', () => {
+  it('should correctly mask BRA documents', async () => {
     const Component = () => {
+      const [document, setDocument] = React.useState('11111111111')
       return (
         <DocumentField
           label="Document"
           documentType="cpf"
-          document="11111111111"
+          document={document}
+          onChange={(data: { document: string }) => setDocument(data.document)}
         />
       )
     }
@@ -19,10 +21,10 @@ describe('DocumentField', () => {
 
     const input = getByLabelText(/document/i)
 
-    expect(input).toHaveValue('111.111.111-11')
+    await wait(() => void expect(input).toHaveValue('111.111.111-11'))
   })
 
-  it('should clamp exceeding characters on change', () => {
+  it('should only mask value on field blur', () => {
     const Component: React.FC = () => {
       const [document, setDocument] = React.useState('')
       const [documentType, setDocumentType] = React.useState('cpf')
@@ -49,16 +51,86 @@ describe('DocumentField', () => {
 
     const input = getByLabelText(/document/i)
 
+    fireEvent.focus(input)
+
     fireEvent.change(input, { target: { value: '123456789' } })
 
-    expect(input).toHaveValue('123.456.789')
+    expect(input).toHaveValue('123456789')
 
     fireEvent.change(input, { target: { value: '12345678901' } })
 
-    expect(input).toHaveValue('123.456.789-01')
+    expect(input).toHaveValue('12345678901')
 
-    fireEvent.change(input, { target: { value: '123456789012' } })
+    fireEvent.blur(input)
 
     expect(input).toHaveValue('123.456.789-01')
+  })
+
+  it("should not format if document isn't cpf", () => {
+    const AnotherDocComponent: React.FC = () => {
+      const [document, setDocument] = React.useState('')
+      const [documentType, setDocumentType] = React.useState('another-document')
+
+      const handleDocumentChange = (data: {
+        document: string
+        documentType: string
+      }) => {
+        setDocument(data.document)
+        setDocumentType(data.documentType)
+      }
+
+      return (
+        <DocumentField
+          label="Document"
+          document={document}
+          documentType={documentType}
+          onChange={handleDocumentChange}
+        />
+      )
+    }
+
+    const { getByLabelText } = render(<AnotherDocComponent />)
+
+    const input = getByLabelText(/document/i)
+
+    fireEvent.focus(input)
+
+    fireEvent.change(input, { target: { value: '123456789' } })
+
+    fireEvent.blur(input)
+
+    expect(input).toHaveValue('123456789')
+  })
+
+  it('should allow input of any special characters', () => {
+    const Component: React.FC = () => {
+      const [document, setDocument] = React.useState('')
+      const [documentType, setDocumentType] = React.useState('')
+
+      const handleDocumentChange = (data: {
+        document: string
+        documentType: string
+      }) => {
+        setDocument(data.document)
+        setDocumentType(data.documentType)
+      }
+
+      return (
+        <DocumentField
+          label="Document"
+          document={document}
+          documentType={documentType}
+          onChange={handleDocumentChange}
+        />
+      )
+    }
+
+    const { getByLabelText } = render(<Component />)
+
+    const input = getByLabelText(/document/i)
+
+    fireEvent.change(input, { target: { value: 'abc123.,[]&*()' } })
+
+    expect(input).toHaveValue('abc123.,[]&*()')
   })
 })

--- a/react/package.json
+++ b/react/package.json
@@ -12,7 +12,7 @@
     "@types/node": "^13.9.3",
     "@types/react": "^16.9.25",
     "@vtex/styleguide": "^9.112.26",
-    "@vtex/test-tools": "^3.0.3",
+    "@vtex/test-tools": "^3.1.0",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.96.1/public/@types/vtex.render-runtime",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.26/public/@types/vtex.styleguide"
   },

--- a/react/utils/validation.ts
+++ b/react/utils/validation.ts
@@ -1,11 +1,15 @@
 export const CPF_MASK = '999.999.999-99'
 
-export const unmaskCPF = (value: string) => value.replace(/\D/g, '')
+const unmaskCPF = (value: string) => value.replace(/\D/g, '')
 
 export const validateCPF = (value: string) => {
   const unmaskedValue = unmaskCPF(value)
 
-  if (unmaskedValue.length < 11) {
+  if (unmaskedValue.length !== 11) {
+    return false
+  }
+
+  if (unmaskedValue.split('').every(digit => digit === unmaskedValue[0])) {
     return false
   }
 

--- a/react/utils/validation.ts
+++ b/react/utils/validation.ts
@@ -1,3 +1,4 @@
+export const CPF_LENGTH = 11
 export const CPF_MASK = '999.999.999-99'
 
 const unmaskCPF = (value: string) => value.replace(/\D/g, '')
@@ -5,7 +6,7 @@ const unmaskCPF = (value: string) => value.replace(/\D/g, '')
 export const validateCPF = (value: string) => {
   const unmaskedValue = unmaskCPF(value)
 
-  if (unmaskedValue.length !== 11) {
+  if (unmaskedValue.length !== CPF_LENGTH) {
     return false
   }
 

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1462,10 +1462,10 @@
     vtex-tachyons "^3.2.0"
     whatwg-fetch "2.0.4"
 
-"@vtex/test-tools@^3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@vtex/test-tools/-/test-tools-3.0.3.tgz#1538e5f405911d5ea362570ee9f33166a7910286"
-  integrity sha512-X946xDUaVBPstHF7fa6O5+Ea+ZvCYsS+3uUrNfNpf5e7LQNI5GwE71B2k/Viztiq8fnAwnWEXIDMIl9Ye2EBYw==
+"@vtex/test-tools@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@vtex/test-tools/-/test-tools-3.1.0.tgz#05d9d2574a57c791b342d0156ac52fccb8843729"
+  integrity sha512-ZZd3IP042R7v/5SbdHAxo6STuy7MldoCv4apSK6lIb9jJfm6K5dzEQBVroY+uQj5tf+tnpM5pTjaqSJu0u/icw==
   dependencies:
     "@babel/core" "^7.8.4"
     "@babel/plugin-proposal-class-properties" "^7.7.4"


### PR DESCRIPTION
#### What problem is this solving?

This PR changes the masking and validation behavior of the first version of this app. According to our designers, the input should only mask after blurring the field, and it should also accept any characters (including those that can be part of the masked value).

[Related clubhouse story](https://app.clubhouse.io/vtex/story/37754/ajustes-na-etapa-de-pagamento)

#### How should this be manually tested?

[Workspace](https://lucas--checkoutio.myvtex.com/checkout/#profile).

You can see the updated behavior on both the profile form and in the cardholder document input in payment.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->